### PR TITLE
refactor: Dataclass to NamedTuple

### DIFF
--- a/mosheh/handlers/python.py
+++ b/mosheh/handlers/python.py
@@ -365,7 +365,7 @@ def __handle_import(imported_identifier: ImportedIdentifier) -> StandardReturn:
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     return data
 
@@ -469,7 +469,7 @@ def _handle_import_from(
             code=code,
         )
         data: StandardReturn = standard_struct()
-        data.update(contract.as_dict)
+        data.update(contract._asdict())
 
         struct.append(data)
 
@@ -524,7 +524,7 @@ def _handle_assign(
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     struct.append(data)
 
@@ -581,7 +581,7 @@ def _handle_annassign(
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     struct.append(data)
 
@@ -833,7 +833,7 @@ def _handle_function_def(
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     struct.append(data)
 
@@ -898,7 +898,7 @@ def _handle_async_function_def(
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     struct.append(data)
 
@@ -1046,7 +1046,7 @@ def _handle_class_def(
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     struct.append(data)
 
@@ -1098,7 +1098,7 @@ def _handle_assert(
 
     data: StandardReturn = standard_struct()
 
-    data.update(contract.as_dict)
+    data.update(contract._asdict())
 
     struct.append(data)
 

--- a/mosheh/types/contracts.py
+++ b/mosheh/types/contracts.py
@@ -7,8 +7,7 @@ These dataclasses are used to ensure the correct value type and attribution, so 
 time each of them appears, they are going to have the desired and expected behavior.
 """
 
-from dataclasses import asdict, dataclass
-from typing import Any, Self
+from typing import NamedTuple
 
 from mosheh.types.basic import (
     Annotation,
@@ -29,17 +28,7 @@ from mosheh.types.basic import (
 from mosheh.types.enums import FunctionType, ImportType, Statement
 
 
-@dataclass
-class BaseContract:
-    """Base dataclass to shortcut `as_dict` definition."""
-
-    @property
-    def as_dict(self: Self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class ImportContract(BaseContract):
+class ImportContract(NamedTuple):
     """`ast.Import` contract for typing and declaration security."""
 
     statement: Statement
@@ -49,8 +38,7 @@ class ImportContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class ImportFromContract(BaseContract):
+class ImportFromContract(NamedTuple):
     """`ast.ImportFrom` contract for typing and declaration security."""
 
     statement: Statement
@@ -60,8 +48,7 @@ class ImportFromContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class AssignContract(BaseContract):
+class AssignContract(NamedTuple):
     """`ast.Assign` contract for typing and declaration security."""
 
     statement: Statement
@@ -70,8 +57,7 @@ class AssignContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class AnnAssignContract(BaseContract):
+class AnnAssignContract(NamedTuple):
     """`ast.AnnAssign` contract for typing and declaration security."""
 
     statement: Statement
@@ -81,8 +67,7 @@ class AnnAssignContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class FunctionDefContract(BaseContract):
+class FunctionDefContract(NamedTuple):
     """`ast.FunctionDef` contract for typing and declaration security."""
 
     statement: Statement
@@ -96,8 +81,7 @@ class FunctionDefContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class AsyncFunctionDefContract(BaseContract):
+class AsyncFunctionDefContract(NamedTuple):
     """`ast.AsyncFunctionDef` contract for typing and declaration security."""
 
     statement: Statement
@@ -111,8 +95,7 @@ class AsyncFunctionDefContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class ClassDefContract(BaseContract):
+class ClassDefContract(NamedTuple):
     """`ast.ClassDef` contract for typing and declaration security."""
 
     statement: Statement
@@ -124,8 +107,7 @@ class ClassDefContract(BaseContract):
     code: CodeSnippet
 
 
-@dataclass
-class AssertContract(BaseContract):
+class AssertContract(NamedTuple):
     """`ast.Assert` contract for typing and declaration security."""
 
     statement: Statement

--- a/tests/unittest/types/contracts.py
+++ b/tests/unittest/types/contracts.py
@@ -28,7 +28,7 @@ def test_import_contract() -> None:
     }
 
     assert isinstance(contract, ImportContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_import_from_contract() -> None:
@@ -49,7 +49,7 @@ def test_import_from_contract() -> None:
     }
 
     assert isinstance(contract, ImportFromContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_assign_contract() -> None:
@@ -65,7 +65,7 @@ def test_assign_contract() -> None:
     }
 
     assert isinstance(contract, AssignContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_ann_assign_contract() -> None:
@@ -86,7 +86,7 @@ def test_ann_assign_contract() -> None:
     }
 
     assert isinstance(contract, AnnAssignContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_class_contract() -> None:
@@ -111,7 +111,7 @@ def test_class_contract() -> None:
     }
 
     assert isinstance(contract, ClassDefContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_function_contract() -> None:
@@ -140,7 +140,7 @@ def test_function_contract() -> None:
     }
 
     assert isinstance(contract, FunctionDefContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_async_function_contract() -> None:
@@ -169,7 +169,7 @@ def test_async_function_contract() -> None:
     }
 
     assert isinstance(contract, FunctionDefContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected
 
 
 def test_assert_contract() -> None:
@@ -185,4 +185,4 @@ def test_assert_contract() -> None:
     }
 
     assert isinstance(contract, AssertContract)
-    assert contract.as_dict == expected
+    assert contract._asdict() == expected


### PR DESCRIPTION
## PR's Metadata

Urgency: low <!-- The "must resolve this now" factor of this PR -->
Scope: Back-End <!-- Where this updates the codebase in general terms: Docs | DB -->
Impact: low <!-- Size of impact this updates causes -->

Related to: #1 <!-- PR's or issues this one is related to: #556 #762 -->
Implements:  #1 <!-- PR's or issues this one is resolving: #4002 #8922 -->
Depends on: Not Applicable  <!-- PR's or issues this one depends but is not blocked by: #404 -->
Blocked by: Not Applicable <!-- PR's or issues blocking this one: #17 #22 -->

Updated Tests: Yes

## Deployment Considerations

- New Command, Flag or Arg: Not Applicable
- Documentation Updated: Not Applicable
- CI/CD Impact: No

## Changelog Updates

### Update

- Refactored dataclass implementations to use NamedTuple
- Updated method calls from `.as_dict()` to `._asdict()`